### PR TITLE
feat: separate jwt validity period for mobile, lasting 1 day

### DIFF
--- a/src/main/java/booking_app_team_2/bookie/controller/AuthenticationController.java
+++ b/src/main/java/booking_app_team_2/bookie/controller/AuthenticationController.java
@@ -6,6 +6,7 @@ import booking_app_team_2.bookie.dto.UserRegistrationDTO;
 import booking_app_team_2.bookie.dto.UserTokenStateDTO;
 import booking_app_team_2.bookie.service.UserService;
 import booking_app_team_2.bookie.util.TokenUtils;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -40,7 +41,8 @@ public class AuthenticationController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<UserTokenStateDTO> logIn(@RequestBody UserAuthenticationDTO userAuthenticationDTO) {
+    public ResponseEntity<UserTokenStateDTO> logIn(@RequestBody UserAuthenticationDTO userAuthenticationDTO,
+                                                   HttpServletRequest httpServletRequest) {
         Authentication authentication = authenticationManager.authenticate(
                 new UsernamePasswordAuthenticationToken(
                         userAuthenticationDTO.getUsername(),
@@ -51,6 +53,7 @@ public class AuthenticationController {
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
         User user = (User) authentication.getPrincipal();
+        tokenUtils.setUserAgent(httpServletRequest.getHeader("User-Agent"));
         String jWT = tokenUtils.generateToken(user);
         int validityPeriod = tokenUtils.getValidityPeriod();
 

--- a/src/main/java/booking_app_team_2/bookie/util/TokenUtils.java
+++ b/src/main/java/booking_app_team_2/bookie/util/TokenUtils.java
@@ -7,6 +7,7 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
@@ -22,11 +23,18 @@ public class TokenUtils {
     public String secret;
 
     @Getter
+    @Value("86400000")
+    private int validityPeriodMobile;
+
+    @Getter
     @Value("1800000")
-    private int validityPeriod;
+    private int validityPeriodWeb;
 
     @Value("Authorization")
     private String authorizationHeader;
+
+    @Setter
+    private String userAgent = "";
 
     private static final String AUDIENCE_UNKNOWN = "unknown";
     private static final String AUDIENCE_MOBILE = "mobile";
@@ -49,13 +57,22 @@ public class TokenUtils {
                 .compact();
     }
 
-    // TODO: Return correct audience based on device from which the request was issued
+    public int getValidityPeriod() {
+        if (userAgent.equals("Mobile-Android"))
+            return validityPeriodMobile;
+        return validityPeriodWeb;
+    }
+
     private String generateAudience() {
+        if (userAgent.equals("Mobile-Android"))
+            return AUDIENCE_MOBILE;
         return AUDIENCE_WEB;
     }
 
     private Date generateExpirationDate() {
-        return new Date(new Date().getTime() + validityPeriod);
+        if (userAgent.equals("Mobile-Android"))
+            return new Date(new Date().getTime() + validityPeriodMobile);
+        return new Date(new Date().getTime() + validityPeriodWeb);
     }
 
     public String getAuthorizationHeaderFromHeader(HttpServletRequest request) {
@@ -84,6 +101,7 @@ public class TokenUtils {
     public String getUsernameFromToken(String token) {
         try {
             final Claims claims = this.getAllClaimsFromToken(token);
+            assert claims != null;
             return claims.getSubject();
         } catch (ExpiredJwtException ex) {
             throw ex;
@@ -95,6 +113,7 @@ public class TokenUtils {
     public Date getIssuedAtDateFromToken(String token) {
         try {
             final Claims claims = this.getAllClaimsFromToken(token);
+            assert claims != null;
             return claims.getIssuedAt();
         } catch (ExpiredJwtException ex) {
             throw ex;
@@ -106,6 +125,7 @@ public class TokenUtils {
     public String getAudienceFromToken(String token) {
         try {
             final Claims claims = this.getAllClaimsFromToken(token);
+            assert claims != null;
             return claims.getAudience();
         } catch (ExpiredJwtException ex) {
             throw ex;
@@ -117,6 +137,7 @@ public class TokenUtils {
     public Date getExpirationDateFromToken(String token) {
         try {
             final Claims claims = this.getAllClaimsFromToken(token);
+            assert claims != null;
             return claims.getExpiration();
         } catch (ExpiredJwtException ex) {
             throw ex;
@@ -128,6 +149,7 @@ public class TokenUtils {
     public Long getIdFromToken(String token) {
         try {
             final Claims claims = getAllClaimsFromToken(token);
+            assert claims != null;
             return claims.get("id", Long.class);
         } catch (ExpiredJwtException ex) {
             throw ex;


### PR DESCRIPTION
Adds a separate JWT validity period for mobile, lasting 1 day. The correct validity period is returned based on the User-Agent header of the sent request.